### PR TITLE
Fixed math built-ins being overwritten

### DIFF
--- a/dusk/script/math.py
+++ b/dusk/script/math.py
@@ -19,16 +19,16 @@ __all__ = [
 ]
 
 
-def max(a: float, b: float) -> float:
-    raise NotImplementedError
+# (a: float, b: float) -> float
+max = max  # we reassing, because `min` is a built-in
 
 
-def min(a: float, b: float) -> float:
-    raise NotImplementedError
+# (a: float, b: float) -> float:
+min = min  # we reassing, because `max` is a built-in
 
 
-def pow(base: float, exp: float) -> float:
-    raise NotImplementedError
+# (base: float, exp: float) -> float:
+pow = pow  # we reassing, because `pow` is a built-in
 
 
 def sqrt(arg: float) -> float:


### PR DESCRIPTION
In Python, `max`, `min` and `pow` are built-ins. `from dusk.script import *` will overwrite them and thus they can't be used anymore.
This is a compromise, where we don't overwrite them, still define them in `dusk.script.math`, but we specify their signatures in the comments.

Basically, `max`, `min` and `pow` have different signatures depending on whether they're used inside a dusk stencil or inside normal python code. We don't want to make them useless for normal python code, but we want to make it clear to the user what's the signature inside of dusk stencils.