### PR TITLE
Prepared 0.5.0 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dusk
-version = "0.5.0dev"
+version = "0.5.0"
 author = MeteoSwiss
 author_email = "Benjamin.Weber@MeteoSwiss.ch"
 description = "An eDSL front-end for Numerical Weather Prediction dynamical cores"
@@ -12,7 +12,7 @@ url = "https://github.com/dawn-ico/dusk"
 python_requires = ~= 3.8
 packages = find:
 install_requires =
-  dawn4py@git+https://github.com/MeteoSwiss-APN/dawn.git#subdirectory=dawn
+  dawn4py@git+https://github.com/MeteoSwiss-APN/dawn.git@56b9695096c4278c7cdffa827deed348778795e8#subdirectory=dawn
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This is blocked by #62 

The release procedure should go like:

1) Merge #62 
2) Merge this
3) Bump master version to 0.6.0-dev (change dawn4py dependency back to master)

Thus we have the following features for version 0.5.0:

* https://github.com/dawn-ico/dusk/milestone/1?closed=1
* https://github.com/dawn-ico/dusk/pull/48
* https://github.com/dawn-ico/dusk/issues/28