### PR TITLE
Offset of Sparse Fields Set to False

### DIFF
--- a/dusk/grammar.py
+++ b/dusk/grammar.py
@@ -538,7 +538,10 @@ class Grammar:
                     voffset,
                     vbase,
                 )
-            return make_unstructured_offset(True), voffset, vbase
+            if self.ctx.location.is_dense(field_dimension):
+                return make_unstructured_offset(True), voffset, vbase
+            else:
+                return make_unstructured_offset(False), voffset, vbase
 
         # TODO: check if `hindex` is valid for this field's location type
 
@@ -554,7 +557,13 @@ class Grammar:
                 f"Invalid horizontal offset for field '{field.sir.name}'!"
             )
 
-        return make_unstructured_offset(True), voffset, vbase
+        if not self.ctx.location.is_dense(field_dimension):
+            raise DuskSyntaxError(
+                f"Invalid horizontal offset for field '{field.sir.name}'!"
+                "sparse fields do not take an offset (only non-offset read makes sense)"
+            )
+        
+        return make_unstructured_offset(True), voffset, vbase        
 
     @transform(
         OneOf(

--- a/dusk/grammar.py
+++ b/dusk/grammar.py
@@ -181,7 +181,8 @@ class Grammar:
                 value=OneOf(
                     Tuple(
                         elts=FixedList(
-                            Capture(_).to("hindex"), name(Capture("K").to("vindex")),
+                            Capture(_).to("hindex"),
+                            name(Capture("K").to("vindex")),
                         ),
                         ctx=Load,
                     ),
@@ -449,7 +450,10 @@ class Grammar:
             # TODO: does `str` really work here? (what about NaNs, precision, 1e11 notation, etc)
             value = str(value)
 
-        return make_literal_access_expr(value, _type,)
+        return make_literal_access_expr(
+            value,
+            _type,
+        )
 
     @transform(Name(id=Capture(str).to("name"), ctx=AnyContext))
     def var(self, name: str, index: expr = None):
@@ -518,6 +522,12 @@ class Grammar:
         neighbor_iteration = self.ctx.location.current_neighbor_iteration
         field_dimension = self.ctx.location.get_field_dimension(field.sir)
 
+        if hindex is not None and not self.ctx.location.is_dense(field_dimension):
+            raise DuskSyntaxError(
+                f"Invalid horizontal offset for field '{field.sir.name}',"
+                "sparse fields do not take an offset (only non-offset read makes sense)!"
+            )
+
         # TODO: `vindex` is _non-sensical_ if the field is 2d
 
         # TODO: we should check that `field_dimension` is valid for
@@ -538,8 +548,6 @@ class Grammar:
                     voffset,
                     vbase,
                 )
-            if self.ctx.location.is_dense(field_dimension):
-                return make_unstructured_offset(True), voffset, vbase
             else:
                 return make_unstructured_offset(False), voffset, vbase
 
@@ -557,13 +565,7 @@ class Grammar:
                 f"Invalid horizontal offset for field '{field.sir.name}'!"
             )
 
-        if not self.ctx.location.is_dense(field_dimension):
-            raise DuskSyntaxError(
-                f"Invalid horizontal offset for field '{field.sir.name}'!"
-                "sparse fields do not take an offset (only non-offset read makes sense)"
-            )
-        
-        return make_unstructured_offset(True), voffset, vbase        
+        return make_unstructured_offset(True), voffset, vbase
 
     @transform(
         OneOf(
@@ -705,9 +707,13 @@ class Grammar:
         return make_ternary_operator(condition, body, orelse)
 
     @transform(
-        Capture(Call(func=name(Capture(str).to("name")), args=_, keywords=_,)).to(
-            "node"
-        )
+        Capture(
+            Call(
+                func=name(Capture(str).to("name")),
+                args=_,
+                keywords=_,
+            )
+        ).to("node")
     )
     def funcall(self, name: str, node: Call):
         # TODO: bad hardcoded string
@@ -788,7 +794,10 @@ class Grammar:
                 # TODO: bad hardcoded string
                 Capture(OneOf("sum_over", "min_over", "max_over")).to("short_cut_name")
             ),
-            args=FixedList(Capture(expr).to("neighborhood"), Capture(expr).to("expr"),),
+            args=FixedList(
+                Capture(expr).to("neighborhood"),
+                Capture(expr).to("expr"),
+            ),
             keywords=Repeat(
                 keyword(
                     arg=Capture(str).append("kwargs_keys"),
@@ -861,4 +870,10 @@ class Grammar:
             # TODO: check for `kwargs["weight"].ctx == Load`?
             weights = [self.expression(weight) for weight in kwargs["weights"].elts]
 
-        return make_reduction_over_neighbor_expr(op, expr, init, neighborhood, weights,)
+        return make_reduction_over_neighbor_expr(
+            op,
+            expr,
+            init,
+            neighborhood,
+            weights,
+        )

--- a/dusk/semantics.py
+++ b/dusk/semantics.py
@@ -114,10 +114,10 @@ class LocationHelper:
             == "unstructured_horizontal_dimension"
         )
         dimension = field.field_dimensions.unstructured_horizontal_dimension
-        if 0 < len(dimension.sparse_part):
-            return list(dimension.sparse_part)
+        if len(dimension.iter_space.chain) > 1:
+            return list(dimension.iter_space.chain)
         else:
-            return [dimension.dense_location_type]
+            return [dimension.iter_space.chain[0]]
 
     @staticmethod
     def is_ambiguous(chain: LocationChain) -> bool:

--- a/dusk/semantics.py
+++ b/dusk/semantics.py
@@ -114,10 +114,7 @@ class LocationHelper:
             == "unstructured_horizontal_dimension"
         )
         dimension = field.field_dimensions.unstructured_horizontal_dimension
-        if len(dimension.iter_space.chain) > 1:
-            return list(dimension.iter_space.chain)
-        else:
-            return [dimension.iter_space.chain[0]]
+        return dimension.iter_space.chain
 
     @staticmethod
     def is_ambiguous(chain: LocationChain) -> bool:

--- a/dusk/transpile.py
+++ b/dusk/transpile.py
@@ -9,7 +9,7 @@ from io import TextIOBase
 from dusk.grammar import Grammar
 
 from dawn4py import compile, CodeGenBackend, set_verbosity, LogLevel
-from dawn4py.serialization import pprint, make_sir, to_json as sir_to_json
+from dawn4py.serialization import make_sir, to_json as sir_to_json
 from dawn4py.serialization.SIR import GridType, SIR
 from dawn4py._dawn4py import run_optimizer_sir
 

--- a/tests/examples/interpolation_sph.py
+++ b/tests/examples/interpolation_sph.py
@@ -1,0 +1,16 @@
+from dusk.script import *
+
+@stencil
+def interpolation_sph(xn: Field[Cell], yn: Field[Cell], xc: Field[Cell], yc: Field[Cell],
+       fn: Field[Cell], f_intp: Field[Cell], h: Field[Cell], pi: Field[Cell]):
+   wij: Field[Cell > Edge > Cell]
+   qij: Field[Cell > Edge > Cell]
+   Wn: Field[Cell]
+   with levels_upward:
+       with sparse[Cell > Edge > Cell]:
+           qij = sqrt((xc[Cell > Edge > Cell]-xn[Cell > Edge > Cell])*(xc[Cell > Edge > Cell]-xn[Cell > Edge > Cell]) 
+                    + (yc[Cell > Edge > Cell]-yn[Cell > Edge > Cell])*(yc[Cell > Edge > Cell]-yn[Cell > Edge > Cell]))/h[Cell > Edge > Cell]
+           wij = 1./(pi[Cell > Edge > Cell]*h[Cell > Edge > Cell]*h[Cell > Edge > Cell])*exp(-qij*qij)
+
+       Wn = sum_over(Cell > Edge > Cell, wij)
+       f_intp = sum_over(Cell > Edge > Cell, 1/Wn[Cell > Edge > Cell]*wij*fn[Cell > Edge > Cell])

--- a/tests/examples/interpolation_sph.py
+++ b/tests/examples/interpolation_sph.py
@@ -1,16 +1,43 @@
 from dusk.script import *
 
-@stencil
-def interpolation_sph(xn: Field[Cell], yn: Field[Cell], xc: Field[Cell], yc: Field[Cell],
-       fn: Field[Cell], f_intp: Field[Cell], h: Field[Cell], pi: Field[Cell]):
-   wij: Field[Cell > Edge > Cell]
-   qij: Field[Cell > Edge > Cell]
-   Wn: Field[Cell]
-   with levels_upward:
-       with sparse[Cell > Edge > Cell]:
-           qij = sqrt((xc[Cell > Edge > Cell]-xn[Cell > Edge > Cell])*(xc[Cell > Edge > Cell]-xn[Cell > Edge > Cell]) 
-                    + (yc[Cell > Edge > Cell]-yn[Cell > Edge > Cell])*(yc[Cell > Edge > Cell]-yn[Cell > Edge > Cell]))/h[Cell > Edge > Cell]
-           wij = 1./(pi[Cell > Edge > Cell]*h[Cell > Edge > Cell]*h[Cell > Edge > Cell])*exp(-qij*qij)
 
-       Wn = sum_over(Cell > Edge > Cell, wij)
-       f_intp = sum_over(Cell > Edge > Cell, 1/Wn[Cell > Edge > Cell]*wij*fn[Cell > Edge > Cell])
+@stencil
+def interpolation_sph(
+    xn: Field[Cell],
+    yn: Field[Cell],
+    xc: Field[Cell],
+    yc: Field[Cell],
+    fn: Field[Cell],
+    f_intp: Field[Cell],
+    h: Field[Cell],
+    pi: Field[Cell],
+):
+    wij: Field[Cell > Edge > Cell]
+    qij: Field[Cell > Edge > Cell]
+    Wn: Field[Cell]
+    with levels_upward:
+        with sparse[Cell > Edge > Cell]:
+            qij = (
+                sqrt(
+                    (xc[Cell > Edge > Cell] - xn[Cell > Edge > Cell])
+                    * (xc[Cell > Edge > Cell] - xn[Cell > Edge > Cell])
+                    + (yc[Cell > Edge > Cell] - yn[Cell > Edge > Cell])
+                    * (yc[Cell > Edge > Cell] - yn[Cell > Edge > Cell])
+                )
+                / h[Cell > Edge > Cell]
+            )
+            wij = (
+                1.0
+                / (
+                    pi[Cell > Edge > Cell]
+                    * h[Cell > Edge > Cell]
+                    * h[Cell > Edge > Cell]
+                )
+                * exp(-qij * qij)
+            )
+
+        Wn = sum_over(Cell > Edge > Cell, wij)
+        f_intp = sum_over(
+            Cell > Edge > Cell,
+            1 / Wn[Cell > Edge > Cell] * wij * fn[Cell > Edge > Cell],
+        )

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -2,8 +2,9 @@ from dusk.transpile import callable_to_pyast, pyast_to_sir, validate
 
 from laplacian_fd import laplacian_fd
 from laplacian_fvm import laplacian_fvm
-
+from interpolation_sph import interpolation_sph
 
 def test_examples():
     validate(pyast_to_sir(callable_to_pyast(laplacian_fd)))
     validate(pyast_to_sir(callable_to_pyast(laplacian_fvm)))
+    validate(pyast_to_sir(callable_to_pyast(interpolation_sph)))

--- a/tests/stencils/test_fields.py
+++ b/tests/stencils/test_fields.py
@@ -58,8 +58,8 @@ def h_offsets(
 ):
     with levels_upward:
         with sparse[Edge > Cell > Edge]:
-            a = b[Edge > Cell > Edge] + c  # no offsets, defaults to Edge > Cell > Edge            
-            a = b[Edge]                    # center access for dense field
+            a = b[Edge > Cell > Edge] + c
+            a = b[Edge] + c
 
 
 @stencil

--- a/tests/stencils/test_fields.py
+++ b/tests/stencils/test_fields.py
@@ -58,11 +58,8 @@ def h_offsets(
 ):
     with levels_upward:
         with sparse[Edge > Cell > Edge]:
-            a = b[Edge > Cell > Edge] + c  # no offsets, defaults to Edge > Cell > Edge
-            a = (
-                b[Edge > Cell > Edge] + c[Edge > Cell > Edge]
-            )  # verbose version of the above
-            a = b[Edge] + c[Edge > Cell > Edge]  # center access for dense field
+            a = b[Edge > Cell > Edge] + c  # no offsets, defaults to Edge > Cell > Edge            
+            a = b[Edge]                    # center access for dense field
 
 
 @stencil
@@ -80,8 +77,8 @@ def hv_offsets(
     with levels_upward as k:
         with sparse[Edge > Cell > Edge]:
             a = b[Edge, k] + c
-            a = b[Edge > Cell > Edge, k + 1] + c[Edge > Cell > Edge, k]
-            a = b[Edge, k] + b[Edge, k - 1] + c[Edge > Cell > Edge]
+            a = b[Edge > Cell > Edge, k + 1] + c[k]
+            a = b[Edge, k] + b[Edge, k - 1] + c
 
 
 @stencil

--- a/tests/stencils/test_reduce.py
+++ b/tests/stencils/test_reduce.py
@@ -36,7 +36,10 @@ def various_reductions(
                 - sum_over(
                     Edge > Cell,
                     sqrt(cell),
-                    weights=[edge[Edge], arcsin(edge[Edge] * 100),],
+                    weights=[
+                        edge[Edge],
+                        arcsin(edge[Edge] * 100),
+                    ],
                 ),
             ),
             mul,

--- a/tests/stencils/test_vertical_index_fields.py
+++ b/tests/stencils/test_vertical_index_fields.py
@@ -57,9 +57,7 @@ def various_expression(
         edge_3d_field2 = sum_over(
             Cell > Vertex > Cell > Edge,
             tan(
-                sparse_3d_field3[
-                    Cell > Vertex > Cell > Edge, sparse_3d_index_field3 + 3,
-                ]
+                sparse_3d_field3[sparse_3d_index_field3 + 3]
             )
             / edge_3d_field1[edge_3d_index_field + 1]
             + reduce_over(


### PR DESCRIPTION
## Technical Description

This PR introduces sets the offset of sparse offset to false (was true before). In a non-nested situation, this is the only offset that makes sense (representing that the stage index is used for the dense index, not the inner index, which would be a bug 10/10 times). Further considerations may are required for nested situations which are beyond the scope of this PR, see discussion [here](https://github.com/dawn-ico/dusk/issues/61). 

Since the offsets of sparse fields are not ambiguous anymore, it is now prohibited to specify one.

## Resolves

Fixes #61 
Fixes #39

## Testing

Hard to test this in dusk only, but a new example stencil was added that exhibits sparse field in an ambiguous context, which are now left without offset. 

## Dependencies

Depends on [dawn PR 1083](https://github.com/MeteoSwiss-APN/dawn/pull/1083)